### PR TITLE
Add header depth filter to unnumber low-level headers.

### DIFF
--- a/filters/numbering-depth.lua
+++ b/filters/numbering-depth.lua
@@ -1,0 +1,8 @@
+local numbering_depth = 3
+
+function Header (h)
+  if h.level > numbering_depth then 
+    h.classes:insert 'unnumbered'
+  end
+  return h
+end


### PR DESCRIPTION
This code change introduces a new header depth filter 'numbering-depth.lua' that unnumbers headers with a depth over three.